### PR TITLE
Make Go version configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ You can sponsor me [here](https://github.com/sponsors/jidicula)!
   * Default: `Fuzz`
 * `fuzz-minimize-time` [optional]: Fuzz minimization duration, specified as a `time.Duration` (for example `1h30s`). Corresponds to `-fuzzminimizetime` flag for the `go test` command. If you provide this input, ensure it is less than your job timeout.
   * Default: `10s`
+* `go-version` [optional]: Which version of Go to use for fuzzing. This will be passed on to `actions/setup-go@v3`.
+  * Default: `1.18`
   
 ## Returns:
 * SUCCESS: if your fuzz tests don't raise a failure within the `fuzz-time` input constraint.

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,10 @@ inputs:
     description: 'Fuzz minimization duration, specified as a `time.Duration` (for example `1h30s`). Corresponds to `-fuzzminimizetime` flag for the `go test` command. If you provide this input, ensure it is less than your job timeout.'
     required: false
     default: '10s'
+  go-version:
+    description: 'Which version of Go to use for fuzzing'
+    required: false
+    default: '1.18'
 
 runs:
   using: 'composite'
@@ -28,7 +32,7 @@ runs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v3
       with:
-        go-version: '1.18'
+        go-version: '${{ inputs.go-version }}'
     - shell: bash
       run: go test "${{ inputs.packages }}" -fuzz="${{ inputs.fuzz-regexp }}" -fuzztime="${{ inputs.fuzz-time }}" -fuzzminimizetime="${{ inputs.fuzz-minimize-time }}"
     - name: Upload fuzz failure seed corpus as run artifact


### PR DESCRIPTION
With Go 1.19 out and 1.20 on the horizon, the version of Go should be user selectable. The default remains 1.18 in order to not change the behaviour for existing users of this action.