### PR TITLE
config: Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @jidicula

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,5 @@ updates:
   open-pull-requests-limit: 99
   commit-message:
     prefix: "build: "
-  reviewers:
-    - "jidicula"
   assignees:
     - "jidicula"


### PR DESCRIPTION
See https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners